### PR TITLE
Github rename

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @kr-project/ecosystem
+* @coda-hq/ecosystem

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Coda Packs Examples
 
 This repository provides example code and templates for Coda Packs built with Coda's Packs SDK:
-https://github.com/kr-project/packs-sdk
+https://github.com/coda-hq/packs-sdk
 
 ## Prerequisites
 
@@ -22,7 +22,7 @@ The simplest way to get started with the SDK is to install it globally:
 
 ```bash
 # Install the Coda Packs SDK globally on your system.
-npm install --global git+ssh://github.com/kr-project/packs-sdk.git
+npm install --global git+ssh://github.com/coda-hq/packs-sdk.git
 ```
 
 ### Single-Project Install (Recommended)
@@ -35,7 +35,7 @@ Create a new project directory if you haven't already and initialize your projec
 
 ```bash
 # Install the Coda Packs SDK locally in your project.
-npm install --save git+ssh://github.com/kr-project/packs-sdk.git
+npm install --save git+ssh://github.com/coda-hq/packs-sdk.git
 ```
 
 Update your path so you can easily use the `coda` commandline (CLI) that ships with the SDK:

--- a/examples/github/formulas.ts
+++ b/examples/github/formulas.ts
@@ -112,7 +112,7 @@ export const formulas: TypedStandardFormula[] = [
     parameters: [pullRequestUrlParameter, pullRequestReviewActionTypeParameter, pullRequestReviewCommentParameter],
     examples: [
       {
-        params: ['https://github.com/kr-project/packs-examples/pull/123', 'COMMENT', 'Some comment'],
+        params: ['https://github.com/coda-hq/packs-examples/pull/123', 'COMMENT', 'Some comment'],
         result: {
           Id: 12345,
           User: {
@@ -123,7 +123,7 @@ export const formulas: TypedStandardFormula[] = [
           },
           Body: 'Some comment',
           State: 'COMMENTED',
-          Url: 'https://github.com/kr-project/packs-examples/pull/123',
+          Url: 'https://github.com/coda-hq/packs-examples/pull/123',
           CommitId: 'ff3d90e1d62c37b93994078fad0dad37d3e',
         },
       },

--- a/examples/github/test/github_integration.ts
+++ b/examples/github/test/github_integration.ts
@@ -15,7 +15,7 @@ describe('GitHub pack integration test', () => {
       'PullRequests',
       // This integration test assumes you have access to the packs-examples repo, which you should
       // if you're looking at this example!
-      ['https://github.com/kr-project/packs-examples', undefined, PullRequestStateFilter.All],
+      ['https://github.com/coda-hq/packs-examples', undefined, PullRequestStateFilter.All],
       undefined,
       undefined,
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -386,8 +386,8 @@
       "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
     "coda-packs-sdk": {
-      "version": "git+ssh://git@github.com/kr-project/packs-sdk.git#b299b74374becc9ce6ec86d2abd8d9f6e61b5698",
-      "from": "git+ssh://git@github.com/kr-project/packs-sdk.git",
+      "version": "git+ssh://git@github.com/coda-hq/packs-sdk.git#b299b74374becc9ce6ec86d2abd8d9f6e61b5698",
+      "from": "git+ssh://git@github.com/coda-hq/packs-sdk.git",
       "requires": {
         "@types/sinon": "^9.0.10",
         "client-oauth2": "^4.3.3",

--- a/package.json
+++ b/package.json
@@ -9,16 +9,16 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/kr-project/packs-examples.git"
+    "url": "git+https://github.com/coda-hq/packs-examples.git"
   },
   "author": "Jonathan Goldman (jonathan@coda.io)",
   "license": "UNLICENSED",
   "bugs": {
-    "url": "https://github.com/kr-project/packs-examples/issues"
+    "url": "https://github.com/coda-hq/packs-examples/issues"
   },
-  "homepage": "https://github.com/kr-project/packs-examples#readme",
+  "homepage": "https://github.com/coda-hq/packs-examples#readme",
   "dependencies": {
-    "coda-packs-sdk": "git+ssh://git@github.com/kr-project/packs-sdk.git"
+    "coda-packs-sdk": "git+ssh://git@github.com/coda-hq/packs-sdk.git"
   },
   "devDependencies": {
     "@types/chai": "^4.2.14",


### PR DESCRIPTION
Github naming migration -> moving from `kr-project` to `coda-hq` and `experimental` to `coda` 
See details here: https://staging.coda.io/d/Github-Rename-Migration_dZRtl44sES_/Github-Renames_suNid#_lu0cY