### PR TITLE
Rename coda-hq to coda

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @coda-hq/ecosystem
+* @coda/ecosystem

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Coda Packs Examples
 
 This repository provides example code and templates for Coda Packs built with Coda's Packs SDK:
-https://github.com/coda-hq/packs-sdk
+https://github.com/coda/packs-sdk
 
 ## Prerequisites
 
@@ -22,7 +22,7 @@ The simplest way to get started with the SDK is to install it globally:
 
 ```bash
 # Install the Coda Packs SDK globally on your system.
-npm install --global git+ssh://github.com/coda-hq/packs-sdk.git
+npm install --global git+ssh://github.com/coda/packs-sdk.git
 ```
 
 ### Single-Project Install (Recommended)
@@ -37,7 +37,7 @@ Create a new project directory if you haven't already and initialize your projec
 # Initialize npm and follow prompts.
 npm init
 # Install the Coda Packs SDK locally in your project.
-npm install --save git+ssh://github.com/coda-hq/packs-sdk.git
+npm install --save git+ssh://github.com/coda/packs-sdk.git
 ```
 
 Update your path so you can easily use the `coda` commandline (CLI) that ships with the SDK:

--- a/examples/github/formulas.ts
+++ b/examples/github/formulas.ts
@@ -107,7 +107,7 @@ export const formulas: TypedStandardFormula[] = [
     parameters: [pullRequestUrlParameter, pullRequestReviewActionTypeParameter, pullRequestReviewCommentParameter],
     examples: [
       {
-        params: ['https://github.com/coda-hq/packs-examples/pull/123', 'COMMENT', 'Some comment'],
+        params: ['https://github.com/coda/packs-examples/pull/123', 'COMMENT', 'Some comment'],
         result: {
           Id: 12345,
           User: {
@@ -118,7 +118,7 @@ export const formulas: TypedStandardFormula[] = [
           },
           Body: 'Some comment',
           State: 'COMMENTED',
-          Url: 'https://github.com/coda-hq/packs-examples/pull/123',
+          Url: 'https://github.com/coda/packs-examples/pull/123',
           CommitId: 'ff3d90e1d62c37b93994078fad0dad37d3e',
         },
       },

--- a/examples/github/test/github_integration.ts
+++ b/examples/github/test/github_integration.ts
@@ -15,7 +15,7 @@ describe('GitHub pack integration test', () => {
       'PullRequests',
       // This integration test assumes you have access to the packs-examples repo, which you should
       // if you're looking at this example!
-      ['https://github.com/coda-hq/packs-examples', undefined, PullRequestStateFilter.All],
+      ['https://github.com/coda/packs-examples', undefined, PullRequestStateFilter.All],
       undefined,
       undefined,
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
-        "coda-packs-sdk": "git+ssh://git@github.com/coda-hq/packs-sdk.git"
+        "coda-packs-sdk": "git+ssh://git@github.com/coda/packs-sdk.git"
       },
       "devDependencies": {
         "@types/chai": "^4.2.17",
@@ -753,7 +753,7 @@
     },
     "node_modules/coda-packs-sdk": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/coda-hq/packs-sdk.git#f2f795d26d672f4dc9ad6dfafb5bdfd016a915bd",
+      "resolved": "git+ssh://git@github.com/coda/packs-sdk.git#f2f795d26d672f4dc9ad6dfafb5bdfd016a915bd",
       "license": "UNLICENSED",
       "dependencies": {
         "@types/sinon": "^10.0.0",
@@ -3980,8 +3980,8 @@
       "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
     "coda-packs-sdk": {
-      "version": "git+ssh://git@github.com/coda-hq/packs-sdk.git#f2f795d26d672f4dc9ad6dfafb5bdfd016a915bd",
-      "from": "coda-packs-sdk@git+ssh://git@github.com/coda-hq/packs-sdk.git",
+      "version": "git+ssh://git@github.com/coda/packs-sdk.git#f2f795d26d672f4dc9ad6dfafb5bdfd016a915bd",
+      "from": "coda-packs-sdk@git+ssh://git@github.com/coda/packs-sdk.git",
       "requires": {
         "@types/sinon": "^10.0.0",
         "client-oauth2": "^4.3.3",

--- a/package.json
+++ b/package.json
@@ -10,16 +10,16 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/coda-hq/packs-examples.git"
+    "url": "git+https://github.com/coda/packs-examples.git"
   },
   "author": "Jonathan Goldman (jonathan@coda.io)",
   "license": "UNLICENSED",
   "bugs": {
-    "url": "https://github.com/coda-hq/packs-examples/issues"
+    "url": "https://github.com/coda/packs-examples/issues"
   },
-  "homepage": "https://github.com/coda-hq/packs-examples#readme",
+  "homepage": "https://github.com/coda/packs-examples#readme",
   "dependencies": {
-    "coda-packs-sdk": "git+ssh://git@github.com/coda-hq/packs-sdk.git"
+    "coda-packs-sdk": "git+ssh://git@github.com/coda/packs-sdk.git"
   },
   "devDependencies": {
     "@types/chai": "^4.2.17",


### PR DESCRIPTION
Per discussion from https://codaproject.slack.com/archives/G01K0R0BAPR/p1620658218002900 rename the coda-hq org to coda
