### PR TITLE
Update codeowners for examples repo.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @coda/ecosystem
+*                 @coda/packs


### PR DESCRIPTION
PTAL @huayang-codaio @coda/packs 

Dependabot created PRs for this repo but it didn't see them, not sure what's up. Maybe I didn't wait long enough. But maybe the file syntax is wrong, either way, updating this to point to the packs team instead of ecosystem.