### PR TITLE
Add gitignore to template example so that coda init includes it and credential files won't be checked in.

### DIFF
--- a/examples/template/.gitignore
+++ b/examples/template/.gitignore
@@ -1,0 +1,2 @@
+.coda.json
+.coda-credentials.json


### PR DESCRIPTION
PTAL @ekoleda-codaio @coda/packs 