### PR TITLE
Remove .gitignore from example. npm strips it out when installing.

### DIFF
--- a/examples/template/.gitignore
+++ b/examples/template/.gitignore
@@ -1,2 +1,0 @@
-.coda.json
-.coda-credentials.json


### PR DESCRIPTION
PTAL @ekoleda-codaio @coda/packs 