### PR TITLE
Remove version from examples

### DIFF
--- a/examples/dictionary/pack.ts
+++ b/examples/dictionary/pack.ts
@@ -2,7 +2,7 @@ import * as coda from "@codahq/packs-sdk";
 import * as helpers from "./helpers";
 import * as schemas from "./schemas";
 
-export const pack = coda.newPack({version: "1.0"});
+export const pack = coda.newPack();
 
 // The Merriam-Webster API uses an API token, which should be included in
 // request urls in a "key=" parameter, so we configure that here. When

--- a/examples/github/pack.ts
+++ b/examples/github/pack.ts
@@ -3,7 +3,7 @@ import * as helpers from "./helpers";
 import * as schemas from "./schemas";
 import * as types from "./types";
 
-export const pack = coda.newPack({version: "1.0"});
+export const pack = coda.newPack();
 
 // This tells Coda which domain the pack make requests to. Any fetcher
 // requests to other domains won't be allowed.

--- a/examples/template/pack.ts
+++ b/examples/template/pack.ts
@@ -2,7 +2,7 @@ import * as coda from "@codahq/packs-sdk";
 import * as helpers from "./helpers";
 import * as schemas from "./schemas";
 
-export const pack = coda.newPack({version: "1.0"});
+export const pack = coda.newPack();
 
 /**
  * An example formula definition, which calls out to a helper file

--- a/examples/trigonometry/pack.ts
+++ b/examples/trigonometry/pack.ts
@@ -1,6 +1,6 @@
 import * as coda from "@codahq/packs-sdk";
 
-export const pack = coda.newPack({version: "1.1"});
+export const pack = coda.newPack();
 
 const DegreesParameter = coda.makeParameter({
   type: coda.ParameterType.Number,


### PR DESCRIPTION
Now that we support auto-versioning for CLI uploads we should use it by default.