### PR TITLE
Add a tsconfig.json with compilerOptions lib set to es2020

### DIFF
--- a/examples/template/tsconfig.json
+++ b/examples/template/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "lib": ["es2020"]
+  }
+}


### PR DESCRIPTION
This prevents vscode from autocompleting DOM objects that don't exist in packs.

Tested by manually adding a tsconfig.json in an existing project created with `coda init`

Did _not_ test by running the full `coda init` flow from scratch