### PR TITLE
Import full SDK in helpers.ts template

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,5 +49,11 @@ module.exports = {
           camelcase: 'off',
         },
       },
+      {
+        files: ['examples/template/**/*.ts'],
+        rules: {
+          '@typescript-eslint/consistent-type-imports': 'off'
+        },
+      },
     ],
   };

--- a/examples/template/helpers.ts
+++ b/examples/template/helpers.ts
@@ -1,4 +1,4 @@
-import type * as coda from "@codahq/packs-sdk";
+import * as coda from "@codahq/packs-sdk";
 
 /**
  * You can put the complicated business logic of your pack in this file,


### PR DESCRIPTION
Import the full SDK (not just the types) in the template's `helpers.ts` file. Multiple makers have reported being confused why the code they were using in the Web IDE wasn't working in this file. Disabled the ESLint rule that enforces limited imports on for that Pack.