### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,71 +1,30 @@
 # Coda Packs Examples
 
-This repository provides example code and templates for Coda Packs built with Coda's Packs SDK:
-https://github.com/coda/packs-sdk
+This repository contains some example code and templates for Coda Packs built with [Coda's Packs SDK][docs_home]. These sample Packs assume you are developing locally using the Pack CLI, as they include multiple source files and tests.
+
+A more complete set of examples, including those which are compatible with the Pack Studio web editor, are available in the [Samples page][docs_samples] of the documentation.
 
 ## Prerequisites
 
-Make sure you have `node`, `typescript`, `npm` and `yarn` installed. TODO: flesh out recommended steps for installing these.
+Make sure you have `node`, `typescript`, `npm` and `yarn` installed.
 
-## One-time Setup
+## Setup
 
 To be able to work with the examples in this repo, simply run `yarn` to install dependencies.
 
-## Setting Up Your Own Project
-
-When setting up your own project, install the `@codahq/packs-sdk` npm packge and then run `coda init`
-to set up a skeleton project based on the `template` example in this repo.
-
-### Global Install (Quick)
-
-The simplest way to get started with the SDK is to install it globally:
-
-```bash
-# Install the Coda Packs SDK globally on your system.
-npm install --global @codahq/packs-sdk
-```
-
-### Single-Project Install (Recommended)
-
-It's easier to manage dependencies and avoid version conflicts across projects
-if you create a yarn project for your pack and install the SDK and other dependencies
-locally.
-
-Create a new project directory if you haven't already and initialize your project:
-
-```bash
-# Initialize yarn and follow prompts.
-yarn init
-# Install the Coda Packs SDK locally in your project.
-yarn add @codahq/packs-sdk
-```
-
-Update your path so you can easily use the `coda` commandline (CLI) that ships with the SDK:
-
-```bash
-# Make sure to run this from the root directory of your project.
-export PATH=$(pwd)/node_modules/.bin:$PATH
-```
-
-(Globally-installed npm packages link CLI scripts into your system path. Locally installed packages
-live in `./node_modules/.bin` and so are more easily used by updating your path.)
-
-### Initialize an Empty Project
-
-Regardless of whether you install globally or locally, after you install in the SDK,
-run `coda init` to create the structure for a new project and install the necessary dependencies.
-
 ## Running Examples
 
-Use the `coda` commandline tool to execute formulas directly. For example:
+Use the `coda` command line tool to execute formulas directly. For example:
 
 ```bash
-coda execute examples/trigonometry/pack.ts Cosine 0
+npx coda execute examples/trigonometry/pack.ts Cosine 0
 ```
+
+See the guide [Using the command line interface][docs_cli] for more information on how to use the command line tool.
 
 ## Running Example Tests
 
-Each of the accompanying examples include sample unittests. You can run them all with `yarn test`.
+Each of the accompanying examples include sample unit tests. You can run them all with `yarn test`.
 Each example's readme explains how to run those tests individually.
 
 There is also an integration test suite that runs tests that actually connect to the
@@ -98,3 +57,8 @@ The [`github`](examples/github/README.md) pack is a relatively full-featured pac
 OAuth authentication to get user-specific data, and implements both an action formula
 (a formula that can be connected to Coda button that updates a third-party service)
 as well as a sync table.
+
+
+[docs_home]: https://coda.io/packs/build/latest/
+[docs_samples]: https://coda.io/packs/build/latest/samples/
+[docs_cli]: https://coda.io/packs/build/latest/guides/development/cli/


### PR DESCRIPTION
Update the README to point to the documentation, which contains many more examples. Also removed some CLI installation instructions, and linked to the docs on that instead.