### PR TITLE
Attempt to pin circleci node image version to match package.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,13 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>coda/renovate-config"
+  ],
+
+  "packageRules": [
+    {
+      "description": "Pin the cimg/node version to 14.* to match package.json",
+      "matchPackageNames": ["cimg/node"],
+      "allowedVersions": "14.*"
+    }
   ]
 }


### PR DESCRIPTION
I *think* this is the correct syntax, but might need to a take a couple of swings to get it right.

PTAL @coda/packs 