### PR TITLE
Remove nanoid version pin

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,6 @@
   "dependencies": {
     "@codahq/packs-sdk": "1.2.3"
   },
-  "resolutions": {
-    "nanoid": "3.2.0"
-  },
   "devDependencies": {
     "@types/chai": "4.3.4",
     "@types/chai-as-promised": "7.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3324,10 +3324,10 @@ ms@2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nanoid@3.2.0, nanoid@3.3.3:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.2.0.tgz#62667522da6673971cca916a6d3eff3f415ff80c"
-  integrity sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==
+nanoid@3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
+  integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
 
 natural-compare-lite@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
This seems better than just updating the dependency (renovate PR: https://github.com/coda/packs-examples/pull/253)

It goes to version 3.3.3 rather than 3.3.4 because mocha selects that exact version: https://github.com/mochajs/mocha/blob/9f24d0d03fd3dc1d15681d9b1548f77ddbeb9ef3/package.json#L70