### PR TITLE
Adjust lint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,8 @@ module.exports = {
       'prefer-const': 'off',
       'prefer-let/prefer-let': 2,
       'prefer-template': 'off',
+      'comma-dangle': ['error', 'always-multiline'],
+      'semi': ['error', 'always',],
     },
     overrides: [
       {

--- a/examples/box/helpers.ts
+++ b/examples/box/helpers.ts
@@ -23,7 +23,7 @@ export async function searchFolders(context: coda.ExecutionContext,
 export async function getUser(context: coda.ExecutionContext): Promise<User> {
   let response = await context.fetcher.fetch({
     method: "GET",
-    url: "https://api.box.com/2.0/users/me"
+    url: "https://api.box.com/2.0/users/me",
   });
   return response.body;
 }

--- a/examples/box/pack.ts
+++ b/examples/box/pack.ts
@@ -46,7 +46,7 @@ pack.addFormula({
             value: folder.id,
           };
         });
-      }
+      },
     }),
   ],
   resultType: coda.ValueType.String,
@@ -63,7 +63,7 @@ pack.addFormula({
     });
     let file = download.body;
     if (!filename) {
-      filename = getFilename(fileUrl, download.headers)
+      filename = getFilename(fileUrl, download.headers);
     }
     let contentType = download.headers["content-type"] as string;
 
@@ -88,12 +88,12 @@ pack.addFormula({
       method: "POST",
       url: "https://upload.box.com/api/2.0/files/content",
       headers: {
-        ...form.getHeaders()
+        ...form.getHeaders(),
       },
       body: form.getBuffer(),
     });
 
     // Return the ID of the uploaded file.
     return upload.body.entries[0].id;
-  }
+  },
 });

--- a/examples/github/schemas.ts
+++ b/examples/github/schemas.ts
@@ -197,6 +197,6 @@ export const PullRequestSchema = coda.makeObjectSchema({
   // columns to keep tables manageable at creation time and avoid overwhelming
   // users with too many fields.
   featuredProperties: [
-    "url", "author", "created", "modified", "closed", "state", "body"
+    "url", "author", "created", "modified", "closed", "state", "body",
   ],
 });


### PR DESCRIPTION
Enforce trailing commas and semicolons in this repo, to mirror the lint rules for samples in the coda/packs-sdk repo.