### PR TITLE
Add a Vonage (JWT auth) example

### DIFF
--- a/examples/vonage/README.md
+++ b/examples/vonage/README.md
@@ -1,0 +1,18 @@
+# Vonage
+
+This is an example Pack that syncs data from Vonage. The primary purpose of this example is to demonstrate how to perform JWT (JSON Web Token) authentication in a Pack.
+
+Coda doesn't yet have native support for JWT authentication, but when the API uses a shared set of system credentials you can approximate it. This example stores the shared credentials in a file and uses the `jsrsasign` library to generate the JWT. When using this pattern in your own Packs make sure not to check the credentials file into your version control system.
+
+## Setup
+
+To run the example code and actually connect to Vonage, you'll need to sign up for a Vonage account and create a new application. This can be done using the [Vonage API Dashboard](https://dashboard.nexmo.com/). After you have created the application, enter the generated application ID and private key in to the `credentials.ts` file.
+
+
+## Running the Example
+
+To sync the list of conversations run:
+
+```bash
+coda execute examples/vonage/pack.ts Conversations
+```

--- a/examples/vonage/credentials.ts
+++ b/examples/vonage/credentials.ts
@@ -1,9 +1,12 @@
 // A file to hold the credentials used by the Pack.
+
 // It's not possible to use the SDK's system authentication and store these in
 // Coda directly since you need direct access to the values in order to create
 // the JWT.
 // We recommend you don't check this file into your code repository, for example
 // by adding an entry for it in your .gitignore file.
+
+// Create an application and private key at: https://dashboard.nexmo.com/
 
 // The ID of your Vonage application.
 export const ApplicationId = "...";

--- a/examples/vonage/credentials.ts
+++ b/examples/vonage/credentials.ts
@@ -1,0 +1,16 @@
+// A file to hold the credentials used by the Pack.
+// It's not possible to use the SDK's system authentication and store these in
+// Coda directly since you need direct access to the values in order to create
+// the JWT.
+// We recommend you don't check this file into your code repository, for example
+// by adding an entry for it in your .gitignore file.
+
+// The ID of your Vonage application.
+export const ApplicationId = "...";
+
+// The private key generated for your Vonage application.
+export const PrivateKey = `
+-----BEGIN PRIVATE KEY-----
+...
+-----END PRIVATE KEY-----
+`.trim();

--- a/examples/vonage/pack.ts
+++ b/examples/vonage/pack.ts
@@ -75,6 +75,7 @@ pack.addSyncTable({
 });
 
 // Create a JWT using the application ID and private key in credentials.ts.
+// See https://developer.vonage.com/en/getting-started/concepts/authentication#json-web-tokens
 function createJwt(context: coda.ExecutionContext) {
   let now = Date.now() / 1000;
   let header = {

--- a/examples/vonage/pack.ts
+++ b/examples/vonage/pack.ts
@@ -1,0 +1,99 @@
+import * as coda from "@codahq/packs-sdk";
+import * as credentials from "./credentials";
+import * as rs from "jsrsasign";
+
+export const pack = coda.newPack();
+
+const ConversationSchema = coda.makeObjectSchema({
+  properties: {
+    id: {
+      type: coda.ValueType.String,
+    },
+    name: {
+      type: coda.ValueType.String,
+    },
+    display_name: {
+      type: coda.ValueType.String,
+    },
+    image: {
+      type: coda.ValueType.String,
+      codaType: coda.ValueHintType.ImageReference,
+      fromKey: "image_url",
+    },
+  },
+  displayProperty: "name",
+  idProperty: "id",
+  featuredProperties: ["display_name", "image"],
+});
+
+pack.addNetworkDomain("nexmo.com");
+
+pack.addSyncTable({
+  name: "Conversations",
+  description: "Lists the conversations created by the application.",
+  identityName: "Conversation",
+  schema: ConversationSchema,
+  formula: {
+    name: "SyncConversations",
+    description: "Syncs the conversations.",
+    parameters: [],
+    execute: async function (args, context) {
+      // Use the next URL if available, or default to the base URL.
+      let url = context.sync.continuation?.nextUrl as string;
+      if (!url) {
+        url = "https://api.nexmo.com/v1/conversations";
+      }
+
+      // Create a JWT for authentication.
+      let jwt = createJwt(context);
+
+      // Fetch the list of conversations.
+      let response = await context.fetcher.fetch({
+        method: "GET",
+        url: "https://api.nexmo.com/v1/conversations",
+        headers: {
+          Authorization: `Bearer ${jwt}`,
+        },
+      });
+      let conversations = response.body._embedded.conversations;
+      let nextUrl = response.body._links.next;
+
+      // Create a continuation, if there are more conversations available.
+      let continuation;
+      if (nextUrl) {
+        continuation = {
+          nextUrl: nextUrl,
+        };
+      }
+
+      return {
+        result: conversations,
+        continuation: continuation,
+      };
+    },
+  },
+});
+
+// Create a JWT using the application ID and private key in credentials.ts.
+function createJwt(context: coda.ExecutionContext) {
+  let now = Date.now() / 1000;
+  let header = {
+    alg: "RS256",
+    typ: "JWT",
+  };
+  let payload = {
+    application_id: credentials.ApplicationId,
+    iat: now,
+    nbf: now,
+    exp: now + 600, // Expires in 10 minutes.
+    jti: context.invocationToken,
+    acl: {
+      paths: {
+        "/*/conversations/**": {
+          methods: ["GET"],
+        },
+      },
+    },
+  };
+  return rs.KJUR.jws.JWS.sign("RS256", header, payload, credentials.PrivateKey);
+}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@codahq/packs-sdk": "1.7.0",
     "content-disposition": "0.5.4",
     "form-data": "4.0.0",
+    "jsrsasign": "10.9.0",
     "luxon": "3.4.0",
     "mime-types": "2.1.35"
   },
@@ -35,6 +36,7 @@
     "@types/chai": "4.3.9",
     "@types/chai-as-promised": "7.1.7",
     "@types/content-disposition": "0.5.7",
+    "@types/jsrsasign": "10.5.12",
     "@types/luxon": "3.3.1",
     "@types/mime-types": "2.1.3",
     "@types/mocha": "10.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1207,6 +1207,11 @@
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
 
+"@types/jsrsasign@10.5.12":
+  version "10.5.12"
+  resolved "https://registry.yarnpkg.com/@types/jsrsasign/-/jsrsasign-10.5.12.tgz#39ca12e576249f1a5494943d1c0c49c9087bf13d"
+  integrity sha512-sOA+eVnHU+FziThpMhuqs/tjFKe5gHVJKIS7g1BzhXP+e2FS8OvtzM0K3IzFxVksDOr98Gz5FJiZVxZ9uFoHhw==
+
 "@types/luxon@3.3.1":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-3.3.1.tgz#08727da7d81ee6a6c702b9dc6c8f86be010eb4dc"
@@ -3300,6 +3305,11 @@ jsonpath-plus@7.2.0:
   version "7.2.0"
   resolved "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz"
   integrity sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==
+
+jsrsasign@10.9.0:
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/jsrsasign/-/jsrsasign-10.9.0.tgz#cc3f316e7e4c112a976193f9d2c93deb5a0745ee"
+  integrity sha512-QWLUikj1SBJGuyGK8tjKSx3K7Y69KYJnrs/pQ1KZ6wvZIkHkWjZ1PJDpuvc1/28c1uP0KW9qn1eI1LzHQqDOwQ==
 
 just-extend@^4.0.2:
   version "4.2.1"


### PR DESCRIPTION
I've worked with a few developers that need to connect APIs that use JWT (JSON Web Tokens) for authentication. While we don't yet support it natively, it's possible to approximate it using the `jsrsasign` library. I've used this approach with a few personal Packs, but I wanted to create an example I can share with developers when asked.