### PR TITLE
Support ES2022 language features

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,11 @@
 {
     "compilerOptions": {
       /* Basic Options */
-      "target": "ES2016" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */,
+      "target": "ES2022" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */,
       "module": "commonjs" /* Specify module code generation: 'commonjs', 'amd', 'system', 'umd' or 'es2015'. */,
       "lib": [
         /* Specify library files to be included in the compilation:  */
-        "es2017"
+        "es2022"
       ],
       // "allowJs": true,                          /* Allow javascript files to be compiled. */
       // "checkJs": true,                         /* Report errors in .js files. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
       /* Basic Options */
-      "target": "ES2022" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */,
+      "target": "ES2020" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */,
       "module": "commonjs" /* Specify module code generation: 'commonjs', 'amd', 'system', 'umd' or 'es2015'. */,
       "lib": [
         /* Specify library files to be included in the compilation:  */


### PR DESCRIPTION
Update the example Packs project to support ES2022 language features, now that the Packs runtime has been updated to run on Node 18.