### PR TITLE
Fix lint checking

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,6 +20,7 @@ const compat = new FlatCompat({
 });
 
 export default [...compat.extends("./tools/eslint/base_rules.js"), {
+    files: ["**/*.ts"],
     plugins: {
         ban,
         filenames,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,13 +21,12 @@ const compat = new FlatCompat({
 
 export default [...compat.extends("./tools/eslint/base_rules.js"), {
     files: ["**/*.ts"],
+
     plugins: {
         ban,
         filenames,
         local,
-        "prefer-let": preferLet,
         "@typescript-eslint": typescriptEslint,
-        prettier,
     },
 
     languageOptions: {
@@ -48,11 +47,21 @@ export default [...compat.extends("./tools/eslint/base_rules.js"), {
         },
     },
 
-    settings: {},
-
     rules: {
         "@typescript-eslint/restrict-plus-operands": "error",
+    },
 
+    settings: {},
+}, {
+    files: ["examples/**/*.ts"],
+
+    plugins: {
+        "prefer-let": preferLet,
+        "@typescript-eslint": typescriptEslint,
+        prettier,
+    },
+    
+    rules: {
         "@typescript-eslint/no-unused-vars": ["error", {
             varsIgnorePattern: "_.*|response|datasourceUrl|MySchema",
             argsIgnorePattern: "_.*|context|param",

--- a/lib/test_utils.ts
+++ b/lib/test_utils.ts
@@ -1,4 +1,4 @@
-import {assert} from "chai";
+import {assert} from 'chai';
 
 export async function willBeRejected<ErrorT = any>(
   promise: Promise<any>,
@@ -9,16 +9,16 @@ export async function willBeRejected<ErrorT = any>(
     return err;
   }
 
-  throw new Error("Promise unexpectedly resolved");
+  throw new Error('Promise unexpectedly resolved');
 }
 
 export async function willBeRejectedWith<T, ErrorT = any>(
   promise: Promise<T>,
   matcher?: RegExp,
 ): Promise<ErrorT> {
-  let error = await willBeRejected(promise);
+  const error = await willBeRejected(promise);
   if (matcher) {
-    assert.match(error, matcher, "Promise was rejected with unexpected error.");
+    assert.match(error, matcher, 'Promise was rejected with unexpected error.');
   }
   return error as ErrorT;
 }

--- a/lib/test_utils.ts
+++ b/lib/test_utils.ts
@@ -16,7 +16,7 @@ export async function willBeRejectedWith<T, ErrorT = any>(
   promise: Promise<T>,
   matcher?: RegExp,
 ): Promise<ErrorT> {
-  const error = await willBeRejected(promise);
+  let error = await willBeRejected(promise);
   if (matcher) {
     assert.match(error, matcher, "Promise was rejected with unexpected error.");
   }


### PR DESCRIPTION
Adds a `files` option so that the lint checking is applied to TypeScript files (which are not included by default). I've also split out the base rules that should be applied to all typescript files with the ones specific to these examples. This ensures that examples use the [Example Code Style Guide](https://coda.io/packs/build/latest/support/contributing/style/#sample-code) while non-example code (like additional tooling) uses the Coda-default style guide.